### PR TITLE
Fix Rumble channel parsing (again)

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/rumble/RumbleChannelParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/rumble/RumbleChannelParsingHelper.java
@@ -9,7 +9,7 @@ public final class RumbleChannelParsingHelper {
 
     public static String getChannelId(final Element doc) {
         final Element idData =
-                doc.select("div.js-media-subscribe-and-notify").first();
+                doc.select("[data-slug][data-type]").first();
         return getChannelIdAlreadySelected(idData);
     }
 


### PR DESCRIPTION
The rumble webdevs seem to be enjoying themselves lately, making lots of whimsical and wacky changes at BravePipe's expense. Let's select the first element containing both data-slug and data-type attributes, that's more deterministic and should be able to endure their constant meddling.
