### PR TITLE
Fix Rumble channel extractor

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/rumble/extractors/RumbleChannelTabItemsExtractorImpl.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/rumble/extractors/RumbleChannelTabItemsExtractorImpl.java
@@ -1,60 +1,108 @@
 package org.schabi.newpipe.extractor.services.rumble.extractors;
 
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
+
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
+import org.schabi.newpipe.extractor.Image;
+import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
-import org.schabi.newpipe.extractor.services.rumble.RumbleChannelParsingHelper;
-import org.schabi.newpipe.extractor.services.rumble.RumbleParsingHelper;
+import org.schabi.newpipe.extractor.localization.DateWrapper;
+import org.schabi.newpipe.extractor.services.rumble.settings.RumbleSettings;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 
-import static org.schabi.newpipe.extractor.ServiceList.Rumble;
+import java.time.OffsetDateTime;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
 
 public class RumbleChannelTabItemsExtractorImpl extends RumbleBrowseLiveItemExtractorImpl {
 
     @Override
-    protected Elements getAllItems(final Document doc) {
-        return doc.select("div.videostream.thumbnail__grid--item");
+    public List<StreamInfoItemExtractor> extractStreamItems(final Document doc)
+            throws ParsingException {
+        final Element script = doc.selectFirst("rum-videos-grid script[type=application/json]");
+        if (script == null) {
+            return List.of();
+        }
+
+        final JsonArray items;
+        try {
+            items = JsonParser.object().from(script.data()).getArray("items");
+        } catch (final JsonParserException e) {
+            throw new ParsingException("Could not parse the channel listing JSON", e);
+        }
+        if (items == null) {
+            return List.of();
+        }
+
+        final List<StreamInfoItemExtractor> list = new LinkedList<>();
+        for (final Object obj : items) {
+            if (!(obj instanceof JsonObject)) {
+                continue;
+            }
+            final JsonObject item = (JsonObject) obj;
+            if (!"video".equals(item.getString("object_type"))) {
+                continue;
+            }
+            list.add(toInfoItem(item));
+        }
+        return list;
     }
 
-    @Override
-    protected String getStreamUploaderUrl(
-            final Element element)
-            throws ParsingException {
-        final String errMsg = "Could not extract the uploader url";
-        String uploaderUrl = RumbleParsingHelper.extractSafely(false, errMsg,
-                () -> Rumble.getBaseUrl()
-                        + element.select("address.video-item--by > a").first()
-                        .attr("href"));
+    private StreamInfoItemExtractor toInfoItem(final JsonObject item) {
+        final boolean isLive = item.getBoolean("live");
+        final JsonObject by = item.getObject("by");
 
-        if (null == uploaderUrl) { // default to Channel uploader url
-            uploaderUrl = Rumble.getBaseUrl() + "/" + RumbleChannelParsingHelper
-                    .getChannelId(element.parents().last());
+        final String thumb = item.getString("thumb", "");
+        final List<Image> thumbs = List.of(new Image(thumb,
+                Image.HEIGHT_UNKNOWN, Image.WIDTH_UNKNOWN, Image.ResolutionLevel.UNKNOWN));
 
-            if (null == uploaderUrl) {
-                throw new ParsingException(errMsg);
-            }
+        final String textualDate = item.getString("upload_date", null);
+        DateWrapper uploadDate = null;
+        if (textualDate != null) {
+            uploadDate = new DateWrapper(OffsetDateTime.parse(textualDate), false);
         }
-        return uploaderUrl;
+
+        final String views = isLive && !item.isNull("watching_now")
+                ? String.valueOf(item.getInt("watching_now"))
+                : String.valueOf(item.getInt("views"));
+
+        final String duration = isLive ? null : secondsToClock(item.getInt("duration"));
+
+        final boolean isAd = ServiceList.Rumble.getServiceSettings()
+                .isSettingEnabled(RumbleSettings.HIDE_PREMIUM_STREAMS)
+                && isPremium(item);
+
+        return new RumbleSearchVideoStreamInfoItemExtractor(
+                item.getString("title"),
+                item.getString("url"),
+                thumbs,
+                views,
+                textualDate,
+                duration,
+                by != null ? by.getString("name") : null,
+                by != null ? by.getString("url") : null,
+                uploadDate,
+                isLive,
+                isAd
+        );
     }
 
-    @Override
-    protected String getStreamUploaderName(
-            final Element element)
-            throws ParsingException {
+    private static boolean isPremium(final JsonObject item) {
+        return !"public".equals(item.getString("visibility"));
+    }
 
-        final String errMsg = "Could not extract the uploader name";
-        String uploaderName = RumbleParsingHelper.extractSafely(false, errMsg,
-                () -> element.select("address.video-item--by").first()
-                        .getElementsByTag("div").first().text());
-
-        if (null == uploaderName) { // default to Channel uploader url
-            uploaderName = RumbleChannelParsingHelper
-                    .getChannelName(element.parents().last());
-
-            if (null == uploaderName) {
-                throw new ParsingException(errMsg);
-            }
+    private static String secondsToClock(final long totalSeconds) {
+        final long hours = totalSeconds / 3600;
+        final long minutes = (totalSeconds % 3600) / 60;
+        final long seconds = totalSeconds % 60;
+        if (hours > 0) {
+            return String.format(Locale.ROOT, "%d:%02d:%02d", hours, minutes, seconds);
         }
-        return uploaderName;
+        return String.format(Locale.ROOT, "%d:%02d", minutes, seconds);
     }
 }


### PR DESCRIPTION
Makes rumble's channel extractor work again so that subscriptions/channel video list loads. Old stuff seems to be removed, so I rewrote it to grab the channels list of videos/livestreams from the `rum-videos-grid` JSON